### PR TITLE
RDBC-134: TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required 
+dist: trusty
+language: ruby
+rvm:
+  - "2.4.3"
+  - "2.5.0"
+script: bundle exec rake
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libunwind8 wget libicu52 libssl-dev curl unzip gettext libcurl4-openssl-dev zlib1g uuid-dev bzip2
+  - wget https://daily-builds.s3.amazonaws.com/RavenDB-4.0.2-linux-x64.tar.bz2; tar -xjf RavenDB-4.0.2-linux-x64.tar.bz2
+  - sed -i 's/:0/:8080/' ./RavenDB/Server/settings.json
+  - ./RavenDB/Server/Raven.Server --non-interactive &
+  - sleep 1

--- a/ravendb-ruby-client.gemspec
+++ b/ravendb-ruby-client.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("activesupport")
   spec.add_dependency("openssl")
   spec.add_development_dependency("rubocop", "~> 0.52.1")
+  spec.add_development_dependency("rake", "~> 12.3.0")
 
   spec.homepage = "http://ravendb.net"
   spec.license  = "MIT"


### PR DESCRIPTION
You can see example output here: https://travis-ci.org/dabroz/ravendb-ruby-client/jobs/350459610

To enable it for the parent project just log in into Travis with your GitHub account and enable it for `ravendb/ravendb-ruby-client` project.