### PR TITLE
RDBC-139: Use Ruby naming conventions for constants

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -73,17 +73,6 @@ Naming/AccessorMethodName:
     - 'lib/documents/query/query_builder.rb'
     - 'lib/requests/request_executor.rb'
 
-# Offense count: 102
-Naming/ConstantName:
-  Exclude:
-    - 'lib/constants/database.rb'
-    - 'lib/constants/documents.rb'
-    - 'lib/documents/conventions.rb'
-    - 'lib/documents/query/index_query.rb'
-    - 'lib/documents/query/query_tokens.rb'
-    - 'lib/requests/request_executor.rb'
-    - 'lib/requests/request_helpers.rb'
-
 # Offense count: 9
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist, MethodDefinitionMacros.
 # NamePrefix: is_, has_, have_

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ query = session.query({
 ```ruby
 query
   .wait_for_non_stale_results
-  .using_default_operator(RavenDB::QueryOperator::And)  
+  .using_default_operator(RavenDB::QueryOperator::AND)
   .where_equals('manufacturer', 'Apple')
   .where_equals('in_stock', true)
   .where_between('last_update', DateTime.strptime('2017-10-01T00:00:00', '%Y-%m-%dT%H:%M:%S'), DateTime::now)
@@ -265,7 +265,7 @@ value, exact = nil)</pre></td>
     </tr>
     <tr>
         <td><pre lang="ruby">search(field_name, search_terms, 
-operator = RavenDB::SearchOperator::Or)</pre></td>
+operator = RavenDB::SearchOperator::OR)</pre></td>
         <td>Performs full-text search</td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ attachment_result = store.operations.send(
   RavenDB::GetAttachmentOperation.new(
     'Products/1-A', 
     file_name, 
-    RavenDB::AttachmentType::Document
+    RavenDB::AttachmentType::DOCUMENT
   )
 )
 

--- a/lib/constants/database.rb
+++ b/lib/constants/database.rb
@@ -1,42 +1,42 @@
 module RavenDB
   class AccessMode
-    None = "None".freeze
-    ReadOnly = "ReadOnly".freeze
-    ReadWrite = "ReadWrite".freeze
-    Admin = "Admin".freeze
+    NONE = "None".freeze
+    READ_ONLY = "ReadOnly".freeze
+    READ_WRITE = "ReadWrite".freeze
+    ADMIN = "Admin".freeze
   end
 
   class FieldIndexingOption
-    No = "No".freeze
-    Search = "Search".freeze
-    Exact = "Exact".freeze
-    Default = "Default".freeze
+    NO = "No".freeze
+    SEARCH = "Search".freeze
+    EXACT = "Exact".freeze
+    DEFAULT = "Default".freeze
   end
 
   class FieldTermVectorOption
-    No = "No".freeze
-    Yes = "Yes".freeze
-    WithPositions = "WithPositions".freeze
-    WithOffsets = "WithOffsets".freeze
-    WithPositionsAndOffsets = "WithPositionsAndOffsets".freeze
+    NO = "No".freeze
+    YES = "Yes".freeze
+    WITH_POSITIONS = "WithPositions".freeze
+    WITH_OFFSETS = "WithOffsets".freeze
+    WITH_POSITIONS_AND_OFFSETS = "WithPositionsAndOffsets".freeze
   end
 
   class IndexLockMode
-    Unlock = "Unlock".freeze
-    LockedIgnore = "LockedIgnore".freeze
-    LockedError = "LockedError".freeze
-    SideBySide = "SideBySide".freeze
+    UNLOCK = "Unlock".freeze
+    LOCKED_IGNORE = "LockedIgnore".freeze
+    LOCKED_ERROR = "LockedError".freeze
+    SIDE_BY_SIDE = "SideBySide".freeze
   end
 
   class IndexPriority
-    Low = "Low".freeze
-    Normal = "Normal".freeze
-    High = "High".freeze
+    LOW = "Low".freeze
+    NORMAL = "Normal".freeze
+    HIGH = "High".freeze
   end
 
   class OperationStatus
-    Completed = "Completed".freeze
-    Faulted = "Faulted".freeze
-    Running = "Running".freeze
+    COMPLETED = "Completed".freeze
+    FAULTED = "Faulted".freeze
+    RUNNING = "Running".freeze
   end
 end

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -105,9 +105,9 @@ module RavenDB
   end
 
   class ConcurrencyCheckMode
-    Auto = "Auto".freeze
-    Forced = "Forced".freeze
-    Disabled = "Disabled".freeze
+    AUTO = "Auto".freeze
+    FORCED = "Forced".freeze
+    DISABLED = "Disabled".freeze
   end
 
   class AttachmentType

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -75,9 +75,9 @@ module RavenDB
   end
 
   class SpatialConstants
-    DefaultDistanceErrorPct = 0.025
-    EarthMeanRadiusKm = 6371.0087714
-    MilesToKm = 1.60934
+    DEFAULT_DISTANCE_ERROR_PCT = 0.025
+    EARTH_MEAN_RADIUS_KM = 6371.0087714
+    MILES_TO_KM = 1.60934
   end
 
   class SpatialUnit

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -60,18 +60,18 @@ module RavenDB
   end
 
   class FieldConstants
-    CustomSortFieldName = "__customSort".freeze
-    DocumentIdFieldName = "id()".freeze
-    ReduceKeyHashFieldName = "hash(key())".freeze
-    ReduceKeyValueFieldName = "key()".freeze
-    AllFields = "__all_fields".freeze
-    AllStoredFields = "__all_stored_fields".freeze
-    SpatialShapeFieldName = "spatial(shape)".freeze
-    RangeFieldSuffix = "_Range".freeze
-    RangeFieldSuffixLong = "_L_Range".freeze
-    RangeFieldSuffixDouble = "_D_Range".freeze
-    NullValue = "NULL_VALUE".freeze
-    EmptyString = "EMPTY_STRING".freeze
+    CUSTOM_SORT_FIELD_NAME = "__customSort".freeze
+    DOCUMENT_ID_FIELD_NAME = "id()".freeze
+    REDUCE_KEY_HASH_FIELD_NAME = "hash(key())".freeze
+    REDUCE_KEY_VALUE_FIELD_NAME = "key()".freeze
+    ALL_FIELDS = "__all_fields".freeze
+    ALL_STORED_FIELDS = "__all_stored_fields".freeze
+    SPATIAL_SHAPE_FIELD_NAME = "spatial(shape)".freeze
+    RANGE_FIELD_SUFFIX = "_Range".freeze
+    RANGE_FIELD_SUFFIX_LONG = "_L_Range".freeze
+    RANGE_FIELD_SUFFIX_DOUBLE = "_D_Range".freeze
+    NULL_VALUE = "NULL_VALUE".freeze
+    EMPTY_STRING = "EMPTY_STRING".freeze
   end
 
   class SpatialConstants

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -29,10 +29,10 @@ module RavenDB
   end
 
   class OrderingType
-    String = "string".freeze
-    Long = "long".freeze
-    Double = "double".freeze
-    AlphaNumeric = "alphaNumeric".freeze
+    STRING = "string".freeze
+    LONG = "long".freeze
+    DOUBLE = "double".freeze
+    ALPHA_NUMERIC = "alphaNumeric".freeze
   end
 
   class SpatialRelation

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -111,15 +111,15 @@ module RavenDB
   end
 
   class AttachmentType
-    Document = "Document".freeze
-    Revision = "Revision".freeze
+    DOCUMENT = "Document".freeze
+    REVISION = "Revision".freeze
 
     def self.is_document(type)
-      type == Document
+      type == DOCUMENT
     end
 
     def self.is_revision(type)
-      type == Revision
+      type == REVISION
     end
   end
 end

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -1,11 +1,11 @@
 module RavenDB
   class SearchOperator
-    Or = "OR".freeze
-    And = "AND".freeze
+    OR = "OR".freeze
+    AND = "AND".freeze
   end
 
   class QueryOperator < SearchOperator
-    Not = "NOT".freeze
+    NOT = "NOT".freeze
   end
 
   class QueryKeyword

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -9,23 +9,23 @@ module RavenDB
   end
 
   class QueryKeyword
-    Select = "SELECT".freeze
-    Distinct = "DISTINCT".freeze
-    As = "AS".freeze
-    From = "FROM".freeze
-    Index = "INDEX".freeze
-    Include = "INCLUDE".freeze
-    Where = "WHERE".freeze
-    Group = "GROUP".freeze
-    Order = "ORDER".freeze
-    Load = "LOAD".freeze
-    By = "BY".freeze
-    Asc = "ASC".freeze
-    Desc = "DESC".freeze
-    In = "IN".freeze
-    Between = "BETWEEN".freeze
-    All = "ALL".freeze
-    Update = "UPDATE".freeze
+    SELECT = "SELECT".freeze
+    DISTINCT = "DISTINCT".freeze
+    AS = "AS".freeze
+    FROM = "FROM".freeze
+    INDEX = "INDEX".freeze
+    INCLUDE = "INCLUDE".freeze
+    WHERE = "WHERE".freeze
+    GROUP = "GROUP".freeze
+    ORDER = "ORDER".freeze
+    LOAD = "LOAD".freeze
+    BY = "BY".freeze
+    ASC = "ASC".freeze
+    DESC = "DESC".freeze
+    IN = "IN".freeze
+    BETWEEN = "BETWEEN".freeze
+    ALL = "ALL".freeze
+    UPDATE = "UPDATE".freeze
   end
 
   class OrderingType

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -97,11 +97,11 @@ module RavenDB
   end
 
   class PatchStatus
-    DocumentDoesNotExist = "DocumentDoesNotExist".freeze
-    Created = "Created".freeze
-    Patched = "Patched".freeze
-    Skipped = "Skipped".freeze
-    NotModified = "NotModified".freeze
+    DOCUMENT_DOES_NOT_EXIST = "DocumentDoesNotExist".freeze
+    CREATED = "Created".freeze
+    PATCHED = "Patched".freeze
+    SKIPPED = "Skipped".freeze
+    NOT_MODIFIED = "NotModified".freeze
   end
 
   class ConcurrencyCheckMode

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -36,27 +36,27 @@ module RavenDB
   end
 
   class SpatialRelation
-    Within = "within".freeze
-    Contains = "contains".freeze
-    Disjoint = "disjoint".freeze
-    Intersects = "intersects".freeze
+    WITHIN = "within".freeze
+    CONTAINS = "contains".freeze
+    DISJOINT = "disjoint".freeze
+    INTERSECTS = "intersects".freeze
   end
 
   class WhereOperator < SpatialRelation
-    Equals = "equals".freeze
-    NotEquals = "notEquals".freeze
-    GreaterThan = "greaterThan".freeze
-    GreaterThanOrEqual = "greaterThanOrEqual".freeze
-    LessThan = "lessThan".freeze
-    LessThanOrEqual = "lessThanOrEqual".freeze
-    In = "in".freeze
-    AllIn = "allIn".freeze
-    Between = "between".freeze
-    Search = "search".freeze
-    Lucene = "lucene".freeze
-    StartsWith = "startsWith".freeze
-    EndsWith = "endsWith".freeze
-    Exists = "exists".freeze
+    EQUALS = "equals".freeze
+    NOT_EQUALS = "notEquals".freeze
+    GREATER_THAN = "greaterThan".freeze
+    GREATER_THAN_OR_EQUAL = "greaterThanOrEqual".freeze
+    LESS_THAN = "lessThan".freeze
+    LESS_THAN_OR_EQUAL = "lessThanOrEqual".freeze
+    IN = "in".freeze
+    ALL_IN = "allIn".freeze
+    BETWEEN = "between".freeze
+    SEARCH = "search".freeze
+    LUCENE = "lucene".freeze
+    STARTS_WITH = "startsWith".freeze
+    ENDS_WITH = "endsWith".freeze
+    EXISTS = "exists".freeze
   end
 
   class FieldConstants

--- a/lib/constants/documents.rb
+++ b/lib/constants/documents.rb
@@ -81,8 +81,8 @@ module RavenDB
   end
 
   class SpatialUnit
-    Kilometers = "Kilometers".freeze
-    Miles = "Miles".freeze
+    KILOMETERS = "Kilometers".freeze
+    MILES = "Miles".freeze
   end
 
   class RavenServerEvent

--- a/lib/database/operation_executor.rb
+++ b/lib/database/operation_executor.rb
@@ -176,11 +176,11 @@ module RavenDB
         case command.server_response
         when Net::HTTPNotModified
           patch_result = {
-            Status: PatchStatus::NotModified
+            Status: PatchStatus::NOT_MODIFIED
           }
         when Net::HTTPNotFound
           patch_result = {
-            Status: PatchStatus::DocumentDoesNotExist
+            Status: PatchStatus::DOCUMENT_DOES_NOT_EXIST
           }
         else
           document = nil

--- a/lib/database/operation_executor.rb
+++ b/lib/database/operation_executor.rb
@@ -33,18 +33,18 @@ module RavenDB
 
         if @timeout && ((Time.now.to_f - start_time) > @timeout)
           return {
-            status: OperationStatus::Faulted,
+            status: OperationStatus::FAULTED,
             exception: DatabaseLoadTimeoutException.new("The operation did not finish before the timeout end")
           }
         end
 
         case response["Status"]
-        when OperationStatus::Completed
+        when OperationStatus::COMPLETED
           return {
             status: response["Status"],
             response: response
           }
-        when OperationStatus::Faulted
+        when OperationStatus::FAULTED
           exception = ExceptionsFactory.create_from(response["Result"])
 
           if exception.nil?
@@ -57,12 +57,12 @@ module RavenDB
           }
         else
           return {
-            status: OperationStatus::Running
+            status: OperationStatus::RUNNING
           }
         end
       rescue StandardError => exception
         return {
-          status: OperationStatus::Faulted,
+          status: OperationStatus::FAULTED,
           exception: exception
         }
       end
@@ -70,9 +70,9 @@ module RavenDB
 
     def on_next(result)
       case result[:status]
-      when OperationStatus::Completed
+      when OperationStatus::COMPLETED
         result[:response]
-      when OperationStatus::Faulted
+      when OperationStatus::FAULTED
         raise result[:exception]
       else
         sleep 0.5

--- a/lib/documents/conventions.rb
+++ b/lib/documents/conventions.rb
@@ -7,11 +7,19 @@ require "utilities/json"
 
 module RavenDB
   class DocumentConventions
-    MAX_NUMBER_OF_REQUEST_PER_SESSION = 30
-    REQUEST_TIMEOUT = 30
-    DEFAULT_USE_OPTIMISTIC_CONCURRENCY = true
-    MAX_LENGTH_OF_QUERY_USING_GET_URL = 1024 + 512
-    IDENTITY_PARTS_SEPARATOR = "/".freeze
+    @max_number_of_request_per_session = 30
+    @request_timeout = 30
+    @default_use_optimistic_concurrency = true
+    @max_length_of_query_using_get_url = 1024 + 512
+    @identity_parts_separator = "/".freeze
+
+    class << self
+      attr_accessor :max_number_of_request_per_session
+      attr_accessor :request_timeout
+      attr_accessor :default_use_optimistic_concurrency
+      attr_accessor :max_length_of_query_using_get_url
+      attr_accessor :identity_parts_separator
+    end
 
     attr_accessor :set_id_only_if_property_is_defined, :disable_topology_updates, :serializers
 

--- a/lib/documents/conventions.rb
+++ b/lib/documents/conventions.rb
@@ -7,11 +7,11 @@ require "utilities/json"
 
 module RavenDB
   class DocumentConventions
-    MaxNumberOfRequestPerSession = 30
-    RequestTimeout = 30
-    DefaultUseOptimisticConcurrency = true
-    MaxLengthOfQueryUsingGetUrl = 1024 + 512
-    IdentityPartsSeparator = "/".freeze
+    MAX_NUMBER_OF_REQUEST_PER_SESSION = 30
+    REQUEST_TIMEOUT = 30
+    DEFAULT_USE_OPTIMISTIC_CONCURRENCY = true
+    MAX_LENGTH_OF_QUERY_USING_GET_URL = 1024 + 512
+    IDENTITY_PARTS_SEPARATOR = "/".freeze
 
     attr_accessor :set_id_only_if_property_is_defined, :disable_topology_updates, :serializers
 

--- a/lib/documents/document_query.rb
+++ b/lib/documents/document_query.rb
@@ -578,7 +578,7 @@ module RavenDB
       self
     end
 
-    def search(field_name, search_terms, operator = SearchOperator::Or)
+    def search(field_name, search_terms, operator = SearchOperator::OR)
       @builder.search(field_name, add_query_parameter(search_terms), operator)
 
       self

--- a/lib/documents/document_query.rb
+++ b/lib/documents/document_query.rb
@@ -84,7 +84,7 @@ module RavenDB
       @index_query_options = @index_query_options.merge(
         cut_off_etag: nil,
         wait_for_non_stale_results: true,
-        wait_for_non_stale_results_timeout: IndexQuery::DefaultTimeout
+        wait_for_non_stale_results_timeout: IndexQuery::DEFAULT_TIMEOUT
       )
 
       self
@@ -94,7 +94,7 @@ module RavenDB
       @index_query_options = @index_query_options.merge(
         cut_off_etag: cut_off_etag,
         wait_for_non_stale_results: true,
-        wait_for_non_stale_results_timeout: wait_timeout || IndexQuery::DefaultTimeout
+        wait_for_non_stale_results_timeout: wait_timeout || IndexQuery::DEFAULT_TIMEOUT
       )
 
       self
@@ -105,7 +105,7 @@ module RavenDB
         cut_off_etag: nil,
         wait_for_non_stale_results: true,
         wait_for_non_stale_results_as_of_now: true,
-        wait_for_non_stale_results_timeout: wait_timeout || IndexQuery::DefaultTimeout
+        wait_for_non_stale_results_timeout: wait_timeout || IndexQuery::DEFAULT_TIMEOUT
       )
 
       self
@@ -125,7 +125,7 @@ module RavenDB
 
     def get_index_query
       skip = 0
-      take = IndexQuery::DefaultPageSize
+      take = IndexQuery::DEFAULT_PAGE_SIZE
       query = @builder.to_string
 
       unless @skip.nil?

--- a/lib/documents/document_session.rb
+++ b/lib/documents/document_session.rb
@@ -252,7 +252,7 @@ module RavenDB
     end
 
     def increment_requests_count
-      max_requests = DocumentConventions::MaxNumberOfRequestPerSession
+      max_requests = DocumentConventions::MAX_NUMBER_OF_REQUEST_PER_SESSION
 
       @number_of_requests_in_session += 1
 
@@ -261,7 +261,7 @@ module RavenDB
   "of remote calls that a session is allowed to make as an early warning system. Sessions are expected to "\
   "be short lived, and Raven provides facilities like batch saves (call save_changes only once) "\
   "You can increase the limit by setting RavenDB::DocumentConventions::"\
-  "MaxNumberOfRequestPerSession, but it is advisable "\
+  "MAX_NUMBER_OF_REQUEST_PER_SESSION, but it is advisable "\
   "that you'll look into reducing the number of remote calls first, "\
   "since that will speed up your application significantly and result in a"\
   "more responsive application."
@@ -373,7 +373,7 @@ module RavenDB
         change_vector = nil
         raw_entity = conventions.convert_to_raw_entity(document)
 
-        if (DocumentConventions::DefaultUseOptimisticConcurrency &&
+        if (DocumentConventions::DEFAULT_USE_OPTIMISTIC_CONCURRENCY &&
           (ConcurrencyCheckMode::Disabled != info[:concurrency_check_mode])) ||
            (ConcurrencyCheckMode::Forced == info[:concurrency_check_mode])
           change_vector = info[:change_vector] ||
@@ -404,7 +404,7 @@ module RavenDB
 
           if info.key?(:expected_change_vector)
             change_vector = info[:expected_change_vector]
-          elsif DocumentConventions::DefaultUseOptimisticConcurrency
+          elsif DocumentConventions::DEFAULT_USE_OPTIMISTIC_CONCURRENCY
             change_vector = info[:change_vector] || info[:metadata]["@change-vector"]
           end
 

--- a/lib/documents/document_session.rb
+++ b/lib/documents/document_session.rb
@@ -252,7 +252,7 @@ module RavenDB
     end
 
     def increment_requests_count
-      max_requests = DocumentConventions::MAX_NUMBER_OF_REQUEST_PER_SESSION
+      max_requests = DocumentConventions.max_number_of_request_per_session
 
       @number_of_requests_in_session += 1
 
@@ -260,8 +260,8 @@ module RavenDB
         raise "The maximum number of requests (#{max_requests}) allowed for this session has been reached. Raven limits the number "\
   "of remote calls that a session is allowed to make as an early warning system. Sessions are expected to "\
   "be short lived, and Raven provides facilities like batch saves (call save_changes only once) "\
-  "You can increase the limit by setting RavenDB::DocumentConventions::"\
-  "MAX_NUMBER_OF_REQUEST_PER_SESSION, but it is advisable "\
+  "You can increase the limit by setting RavenDB::DocumentConventions."\
+  "max_number_of_request_per_session, but it is advisable "\
   "that you'll look into reducing the number of remote calls first, "\
   "since that will speed up your application significantly and result in a"\
   "more responsive application."
@@ -373,7 +373,7 @@ module RavenDB
         change_vector = nil
         raw_entity = conventions.convert_to_raw_entity(document)
 
-        if (DocumentConventions::DEFAULT_USE_OPTIMISTIC_CONCURRENCY &&
+        if (DocumentConventions.default_use_optimistic_concurrency &&
           (ConcurrencyCheckMode::DISABLED != info[:concurrency_check_mode])) ||
            (ConcurrencyCheckMode::FORCED == info[:concurrency_check_mode])
           change_vector = info[:change_vector] ||
@@ -404,7 +404,7 @@ module RavenDB
 
           if info.key?(:expected_change_vector)
             change_vector = info[:expected_change_vector]
-          elsif DocumentConventions::DEFAULT_USE_OPTIMISTIC_CONCURRENCY
+          elsif DocumentConventions.default_use_optimistic_concurrency
             change_vector = info[:change_vector] || info[:metadata]["@change-vector"]
           end
 

--- a/lib/documents/document_session.rb
+++ b/lib/documents/document_session.rb
@@ -313,19 +313,19 @@ module RavenDB
         document_id = id
         info = @raw_entities_and_metadata[document]
         metadata = document.instance_variable_get("@metadata")
-        check_mode = ConcurrencyCheckMode::Forced
+        check_mode = ConcurrencyCheckMode::FORCED
 
         if document_id.nil?
           document_id = conventions.get_id_from_document(document)
         end
 
         if change_vector.nil?
-          check_mode = ConcurrencyCheckMode::Disabled
+          check_mode = ConcurrencyCheckMode::DISABLED
         else
           info[:change_vector] = metadata["@change-vector"] = change_vector
 
           unless document_id.nil?
-            check_mode = ConcurrencyCheckMode::Auto
+            check_mode = ConcurrencyCheckMode::AUTO
           end
         end
 
@@ -374,8 +374,8 @@ module RavenDB
         raw_entity = conventions.convert_to_raw_entity(document)
 
         if (DocumentConventions::DEFAULT_USE_OPTIMISTIC_CONCURRENCY &&
-          (ConcurrencyCheckMode::Disabled != info[:concurrency_check_mode])) ||
-           (ConcurrencyCheckMode::Forced == info[:concurrency_check_mode])
+          (ConcurrencyCheckMode::DISABLED != info[:concurrency_check_mode])) ||
+           (ConcurrencyCheckMode::FORCED == info[:concurrency_check_mode])
           change_vector = info[:change_vector] ||
                           info[:metadata]["@change-vector"] ||
                           conventions.empty_change_vector
@@ -498,7 +498,7 @@ module RavenDB
         metadata: conversion_result[:metadata],
         change_vector: conversion_result[:metadata]["@change-vector"] || nil,
         id: document_id,
-        concurrency_check_mode: ConcurrencyCheckMode::Auto,
+        concurrency_check_mode: ConcurrencyCheckMode::AUTO,
         document_type: conversion_result[:document_type]
       }
     end

--- a/lib/documents/hilo.rb
+++ b/lib/documents/hilo.rb
@@ -53,7 +53,7 @@ module RavenDB
       @range = HiloRangeValue.new
       @generate_id_lock = Mutex.new
       @last_range_at = TypeUtilities.zero_date
-      @identity_parts_separator = DocumentConventions::IDENTITY_PARTS_SEPARATOR
+      @identity_parts_separator = DocumentConventions.identity_parts_separator
     end
 
     def generate_document_id

--- a/lib/documents/hilo.rb
+++ b/lib/documents/hilo.rb
@@ -53,7 +53,7 @@ module RavenDB
       @range = HiloRangeValue.new
       @generate_id_lock = Mutex.new
       @last_range_at = TypeUtilities.zero_date
-      @identity_parts_separator = DocumentConventions::IdentityPartsSeparator
+      @identity_parts_separator = DocumentConventions::IDENTITY_PARTS_SEPARATOR
     end
 
     def generate_document_id

--- a/lib/documents/indexes.rb
+++ b/lib/documents/indexes.rb
@@ -64,7 +64,7 @@ module RavenDB
         "Name" => @_name,
         "Reduce" => @reduce,
         "OutputReduceToCollection" => nil,
-        "Priority" => @priority || IndexPriority::Normal,
+        "Priority" => @priority || IndexPriority::NORMAL,
         "Type" => type
       }
     end

--- a/lib/documents/query/index_query.rb
+++ b/lib/documents/query/index_query.rb
@@ -1,16 +1,16 @@
 module RavenDB
   class IndexQuery
-    DefaultTimeout = 15 * 1000
-    DefaultPageSize = 2**31 - 1
+    DEFAULT_TIMEOUT = 15 * 1000
+    DEFAULT_PAGE_SIZE = 2**31 - 1
 
     attr_accessor :start, :page_size
     attr_reader :query, :query_parameters, :wait_for_non_stale_results,
                 :wait_for_non_stale_results_as_of_now, :wait_for_non_stale_results_timeout
 
-    def initialize(query = "", query_parameters = {}, page_size = DefaultPageSize, skipped_results = 0, options = {})
+    def initialize(query = "", query_parameters = {}, page_size = DEFAULT_PAGE_SIZE, skipped_results = 0, options = {})
       @query = query
       @query_parameters = query_parameters || {}
-      @page_size = page_size || DefaultPageSize
+      @page_size = page_size || DEFAULT_PAGE_SIZE
       @start = skipped_results || 0
       @cut_off_etag = options[:cut_off_etag] || nil
       @wait_for_non_stale_results = options[:wait_for_non_stale_results] || false
@@ -18,14 +18,14 @@ module RavenDB
       @wait_for_non_stale_results_timeout = options[:wait_for_non_stale_results_timeout] || nil
 
       unless @page_size.is_a?(Numeric)
-        @page_size = DefaultPageSize
+        @page_size = DEFAULT_PAGE_SIZE
       end
 
       if (@wait_for_non_stale_results ||
           @wait_for_non_stale_results_as_of_now) &&
          !@wait_for_non_stale_results_timeout
 
-        @wait_for_non_stale_results_timeout = DefaultTimeout
+        @wait_for_non_stale_results_timeout = DEFAULT_TIMEOUT
       end
     end
 

--- a/lib/documents/query/query_builder.rb
+++ b/lib/documents/query/query_builder.rb
@@ -704,9 +704,9 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::Order)
+        .append(QueryKeyword::ORDER)
         .append(" ")
-        .append(QueryKeyword::By)
+        .append(QueryKeyword::BY)
         .append(" ")
 
       tokens.each do |item|
@@ -725,9 +725,9 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::Group)
+        .append(QueryKeyword::GROUP)
         .append(" ")
-        .append(QueryKeyword::By)
+        .append(QueryKeyword::BY)
         .append(" ")
 
       tokens.each do |item|
@@ -746,7 +746,7 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::Select)
+        .append(QueryKeyword::SELECT)
         .append(" ")
 
       if (tokens.count == 1) && tokens.first.value.is_a?(DistinctToken)
@@ -776,7 +776,7 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::Include)
+        .append(QueryKeyword::INCLUDE)
         .append(" ")
 
       @includes.each_with_index do |include, index|
@@ -813,7 +813,7 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::Where)
+        .append(QueryKeyword::WHERE)
         .append(" ")
 
       if @is_intersect

--- a/lib/documents/query/query_builder.rb
+++ b/lib/documents/query/query_builder.rb
@@ -99,7 +99,7 @@ module RavenDB
     end
 
     def custom_sort_using(type_name, descending = false)
-      field_name = "#{FieldConstants::CustomSortFieldName};#{type_name}"
+      field_name = "#{FieldConstants::CUSTOM_SORT_FIELD_NAME};#{type_name}"
 
       if descending
         order_by_descending(field_name)
@@ -580,7 +580,7 @@ module RavenDB
 
       if @is_group_by && !is_nested_path
         if !@id_property_name.nil? && (field_name == @id_property_name)
-          result[:escaped_field_name] = FieldConstants::DocumentIdFieldName
+          result[:escaped_field_name] = FieldConstants::DOCUMENT_ID_FIELD_NAME
         end
 
         emit(RavenServerEvent::EVENT_QUERY_FIELD_VALIDATED, result)

--- a/lib/documents/query/query_builder.rb
+++ b/lib/documents/query/query_builder.rb
@@ -497,7 +497,7 @@ module RavenDB
 
     def within_radiusof(field_name, radius_parameter_name, latitude_parameter_name,
                         longitude_parameter_name, radius_units = SpatialUnits::Kilometers,
-                        dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
+                        dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       field_name = ensure_valid_field_name(field_name)
 
       append_operator_if_needed(@where_tokens)

--- a/lib/documents/query/query_builder.rb
+++ b/lib/documents/query/query_builder.rb
@@ -393,7 +393,7 @@ module RavenDB
       self
     end
 
-    def search(field_name, search_terms_parameter_name, operator = SearchOperator::Or)
+    def search(field_name, search_terms_parameter_name, operator = SearchOperator::OR)
       field_name = ensure_valid_field_name(field_name)
 
       append_operator_if_needed(@where_tokens)
@@ -614,7 +614,7 @@ module RavenDB
         current = current.previous
       end
 
-      token = if QueryOperator::And == @default_operator
+      token = if @default_operator == QueryOperator::AND
                 QueryOperatorToken.and
               else
                 QueryOperatorToken.or

--- a/lib/documents/query/query_builder.rb
+++ b/lib/documents/query/query_builder.rb
@@ -496,7 +496,7 @@ module RavenDB
     end
 
     def within_radiusof(field_name, radius_parameter_name, latitude_parameter_name,
-                        longitude_parameter_name, radius_units = SpatialUnits::Kilometers,
+                        longitude_parameter_name, radius_units = SpatialUnits::KILOMETERS,
                         dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       field_name = ensure_valid_field_name(field_name)
 

--- a/lib/documents/query/query_tokens.rb
+++ b/lib/documents/query/query_tokens.rb
@@ -698,7 +698,7 @@ module RavenDB
 
         @where_shape.write_to(writer)
 
-        if (@distance_error_pct.to_f - SpatialConstants::DefaultDistanceErrorPct).abs > Float::EPSILON
+        if (@distance_error_pct.to_f - SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT).abs > Float::EPSILON
           writer.append(", ")
           writer.append(@distance_error_pct.to_s)
         end

--- a/lib/documents/query/query_tokens.rb
+++ b/lib/documents/query/query_tokens.rb
@@ -111,7 +111,7 @@ module RavenDB
   class FromToken < QueryToken
     attr_reader :index_name, :collection_name, :is_dynamic
 
-    WhiteSpaceChars = [
+    WHITE_SPACE_CHARS = [
       " ", "\t", "\r", "\n", "\v"
     ].freeze
 
@@ -138,7 +138,7 @@ module RavenDB
           .append(QueryKeyword::From)
           .append(" ")
 
-        if WhiteSpaceChars.any? { |char| @collection_name.include?(char) }
+        if WHITE_SPACE_CHARS.any? { |char| @collection_name.include?(char) }
           if @collection_name.include?('"')
             raise NotSupportedException,
                   "Collection name cannot contain a quote, but was: #{@collection_name}"

--- a/lib/documents/query/query_tokens.rb
+++ b/lib/documents/query/query_tokens.rb
@@ -317,15 +317,15 @@ module RavenDB
       new("random('#{seed.gsub("'", "''")}')")
     end
 
-    def self.create_ascending(field_name, ordering = OrderingType::String)
+    def self.create_ascending(field_name, ordering = OrderingType::STRING)
       new(field_name, false, ordering)
     end
 
-    def self.create_descending(field_name, ordering = OrderingType::String)
+    def self.create_descending(field_name, ordering = OrderingType::STRING)
       new(field_name, true, ordering)
     end
 
-    def initialize(field_name, descending = false, ordering = OrderingType::String)
+    def initialize(field_name, descending = false, ordering = OrderingType::STRING)
       super()
 
       @field_name = field_name
@@ -336,7 +336,7 @@ module RavenDB
     def write_to(writer)
       write_field(writer, @field_name)
 
-      if !@ordering.nil? && (OrderingType::String != @ordering)
+      if !@ordering.nil? && (@ordering != OrderingType::STRING)
         writer
           .append(" ")
           .append(QueryKeyword::AS)

--- a/lib/documents/query/query_tokens.rb
+++ b/lib/documents/query/query_tokens.rb
@@ -263,7 +263,7 @@ module RavenDB
     protected
 
     def token_text
-      QueryOperator::Not
+      QueryOperator::NOT
     end
   end
 
@@ -354,11 +354,11 @@ module RavenDB
 
   class QueryOperatorToken < QueryToken
     def self.and
-      new(QueryOperator::And)
+      new(QueryOperator::AND)
     end
 
     def self.or
-      new(QueryOperator::Or)
+      new(QueryOperator::OR)
     end
 
     def initialize(query_operator)
@@ -505,7 +505,7 @@ module RavenDB
       )
     end
 
-    def self.search(field_name, parameter_name, op = SearchOperator::And)
+    def self.search(field_name, parameter_name, op = SearchOperator::AND)
       new(
         field_name: field_name,
         parameter_name: parameter_name,
@@ -640,7 +640,7 @@ module RavenDB
           .append(" $")
           .append(@from_parameter_name)
           .append(" ")
-          .append(QueryOperator::And)
+          .append(QueryOperator::AND)
           .append(" $")
           .append(@to_parameter_name)
       when WhereOperator::Equals
@@ -672,7 +672,7 @@ module RavenDB
           .append(", $")
           .append(@parameter_name)
 
-        if @search_operator == SearchOperator::And
+        if @search_operator == SearchOperator::AND
           writer
             .append(", ")
             .append(@search_operator)

--- a/lib/documents/query/query_tokens.rb
+++ b/lib/documents/query/query_tokens.rb
@@ -413,7 +413,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         exact: exact,
-        where_operator: WhereOperator::Equals
+        where_operator: WhereOperator::EQUALS
       )
     end
 
@@ -422,7 +422,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         exact: exact,
-        where_operator: WhereOperator::NotEquals
+        where_operator: WhereOperator::NOT_EQUALS
       )
     end
 
@@ -430,7 +430,7 @@ module RavenDB
       new(
         field_name: field_name,
         parameter_name: parameter_name,
-        where_operator: WhereOperator::StartsWith
+        where_operator: WhereOperator::STARTS_WITH
       )
     end
 
@@ -438,7 +438,7 @@ module RavenDB
       new(
         field_name: field_name,
         parameter_name: parameter_name,
-        where_operator: WhereOperator::EndsWith
+        where_operator: WhereOperator::ENDS_WITH
       )
     end
 
@@ -447,7 +447,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         exact: exact,
-        where_operator: WhereOperator::GreaterThan
+        where_operator: WhereOperator::GREATER_THAN
       )
     end
 
@@ -456,7 +456,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         exact: exact,
-        where_operator: WhereOperator::GreaterThanOrEqual
+        where_operator: WhereOperator::GREATER_THAN_OR_EQUAL
       )
     end
 
@@ -465,7 +465,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         exact: exact,
-        where_operator: WhereOperator::LessThan
+        where_operator: WhereOperator::LESS_THAN
       )
     end
 
@@ -474,7 +474,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         exact: exact,
-        where_operator: WhereOperator::LessThanOrEqual
+        where_operator: WhereOperator::LESS_THAN_OR_EQUAL
       )
     end
 
@@ -483,7 +483,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         exact: exact,
-        where_operator: WhereOperator::In
+        where_operator: WhereOperator::IN
       )
     end
 
@@ -491,7 +491,7 @@ module RavenDB
       new(
         field_name: field_name,
         parameter_name: parameter_name,
-        where_operator: WhereOperator::AllIn
+        where_operator: WhereOperator::ALL_IN
       )
     end
 
@@ -501,7 +501,7 @@ module RavenDB
         from_parameter_name: from_parameter_name,
         to_parameter_name: to_parameter_name,
         exact: exact,
-        where_operator: WhereOperator::Between
+        where_operator: WhereOperator::BETWEEN
       )
     end
 
@@ -510,7 +510,7 @@ module RavenDB
         field_name: field_name,
         parameter_name: parameter_name,
         search_operator: op,
-        where_operator: WhereOperator::Search
+        where_operator: WhereOperator::SEARCH
       )
     end
 
@@ -518,14 +518,14 @@ module RavenDB
       new(
         field_name: field_name,
         parameter_name: parameter_name,
-        where_operator: WhereOperator::Lucene
+        where_operator: WhereOperator::LUCENE
       )
     end
 
     def self.exists(field_name)
       new(
         field_name: field_name,
-        where_operator: WhereOperator::Exists
+        where_operator: WhereOperator::EXISTS
       )
     end
 
@@ -534,7 +534,7 @@ module RavenDB
         field_name: field_name,
         where_shape: shape,
         distance_error_pct: distance_error_pct,
-        where_operator: WhereOperator::Within
+        where_operator: WhereOperator::WITHIN
       )
     end
 
@@ -543,7 +543,7 @@ module RavenDB
         field_name: field_name,
         where_shape: shape,
         distance_error_pct: distance_error_pct,
-        where_operator: WhereOperator::Contains
+        where_operator: WhereOperator::CONTAINS
       )
     end
 
@@ -552,7 +552,7 @@ module RavenDB
         field_name: field_name,
         where_shape: shape,
         distance_error_pct: distance_error_pct,
-        where_operator: WhereOperator::Disjoint
+        where_operator: WhereOperator::DISJOINT
       )
     end
 
@@ -561,7 +561,7 @@ module RavenDB
         field_name: field_name,
         where_shape: shape,
         distance_error_pct: distance_error_pct,
-        where_operator: WhereOperator::Intersects
+        where_operator: WhereOperator::INTERSECTS
       )
     end
 
@@ -600,15 +600,15 @@ module RavenDB
       end
 
       case @where_operator
-      when WhereOperator::Search,
-             WhereOperator::Lucene,
-             WhereOperator::StartsWith,
-             WhereOperator::EndsWith,
-             WhereOperator::Exists,
-             WhereOperator::Within,
-             WhereOperator::Contains,
-             WhereOperator::Disjoint,
-             WhereOperator::Intersects
+      when WhereOperator::SEARCH,
+             WhereOperator::LUCENE,
+             WhereOperator::STARTS_WITH,
+             WhereOperator::ENDS_WITH,
+             WhereOperator::EXISTS,
+             WhereOperator::WITHIN,
+             WhereOperator::CONTAINS,
+             WhereOperator::DISJOINT,
+             WhereOperator::INTERSECTS
         writer
           .append(@where_operator)
           .append("(")
@@ -617,14 +617,14 @@ module RavenDB
       write_field(writer, @field_name)
 
       case @where_operator
-      when WhereOperator::In
+      when WhereOperator::IN
         writer
           .append(" ")
           .append(QueryKeyword::IN)
           .append(" ($")
           .append(@parameter_name)
           .append(")")
-      when WhereOperator::AllIn
+      when WhereOperator::ALL_IN
         writer
           .append(" ")
           .append(QueryKeyword::ALL)
@@ -633,7 +633,7 @@ module RavenDB
           .append(" ($")
           .append(@parameter_name)
           .append(")")
-      when WhereOperator::Between
+      when WhereOperator::BETWEEN
         writer
           .append(" ")
           .append(QueryKeyword::BETWEEN)
@@ -643,31 +643,31 @@ module RavenDB
           .append(QueryOperator::AND)
           .append(" $")
           .append(@to_parameter_name)
-      when WhereOperator::Equals
+      when WhereOperator::EQUALS
         writer
           .append(" = $")
           .append(@parameter_name)
-      when WhereOperator::NotEquals
+      when WhereOperator::NOT_EQUALS
         writer
           .append(" != $")
           .append(@parameter_name)
-      when WhereOperator::GreaterThan
+      when WhereOperator::GREATER_THAN
         writer
           .append(" > $")
           .append(@parameter_name)
-      when WhereOperator::GreaterThanOrEqual
+      when WhereOperator::GREATER_THAN_OR_EQUAL
         writer
           .append(" >= $")
           .append(@parameter_name)
-      when WhereOperator::LessThan
+      when WhereOperator::LESS_THAN
         writer
           .append(" < $")
           .append(@parameter_name)
-      when WhereOperator::LessThanOrEqual
+      when WhereOperator::LESS_THAN_OR_EQUAL
         writer
           .append(" <= $")
           .append(@parameter_name)
-      when WhereOperator::Search
+      when WhereOperator::SEARCH
         writer
           .append(", $")
           .append(@parameter_name)
@@ -679,20 +679,20 @@ module RavenDB
         end
 
         writer.append(")")
-      when WhereOperator::Lucene,
-             WhereOperator::StartsWith,
-             WhereOperator::EndsWith
+      when WhereOperator::LUCENE,
+             WhereOperator::STARTS_WITH,
+             WhereOperator::ENDS_WITH
         writer
           .append(", $")
           .append(@parameter_name)
           .append(")")
-      when WhereOperator::Exists
+      when WhereOperator::EXISTS
         writer
           .append(")")
-      when WhereOperator::Within,
-             WhereOperator::Contains,
-             WhereOperator::Disjoint,
-             WhereOperator::Intersects
+      when WhereOperator::WITHIN,
+             WhereOperator::CONTAINS,
+             WhereOperator::DISJOINT,
+             WhereOperator::INTERSECTS
         writer
           .append(", ")
 

--- a/lib/documents/query/query_tokens.rb
+++ b/lib/documents/query/query_tokens.rb
@@ -6,13 +6,13 @@ require "utilities/string_utility"
 module RavenDB
   class QueryToken
     QueryKeywords = [
-      QueryKeyword::As,
-      QueryKeyword::Select,
-      QueryKeyword::Where,
-      QueryKeyword::Load,
-      QueryKeyword::Group,
-      QueryKeyword::Order,
-      QueryKeyword::Include
+      QueryKeyword::AS,
+      QueryKeyword::SELECT,
+      QueryKeyword::WHERE,
+      QueryKeyword::LOAD,
+      QueryKeyword::GROUP,
+      QueryKeyword::ORDER,
+      QueryKeyword::INCLUDE
     ].freeze
 
     def write_to(writer)
@@ -58,7 +58,7 @@ module RavenDB
     protected
 
     def token_text
-      QueryKeyword::Distinct
+      QueryKeyword::DISTINCT
     end
   end
 
@@ -101,7 +101,7 @@ module RavenDB
         next if projection.nil? || (projection == field)
 
         writer.append(" ")
-        writer.append(QueryKeyword::As)
+        writer.append(QueryKeyword::AS)
         writer.append(" ")
         writer.append(projection)
       end
@@ -135,7 +135,7 @@ module RavenDB
 
       if @is_dynamic
         writer
-          .append(QueryKeyword::From)
+          .append(QueryKeyword::FROM)
           .append(" ")
 
         if WHITE_SPACE_CHARS.any? { |char| @collection_name.include?(char) }
@@ -153,9 +153,9 @@ module RavenDB
       end
 
       writer
-        .append(QueryKeyword::From)
+        .append(QueryKeyword::FROM)
         .append(" ")
-        .append(QueryKeyword::Index)
+        .append(QueryKeyword::INDEX)
         .append(" '")
         .append(@index_name)
         .append("'")
@@ -182,7 +182,7 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::As)
+        .append(QueryKeyword::AS)
         .append(" ")
         .append(@field_name)
     end
@@ -208,7 +208,7 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::As)
+        .append(QueryKeyword::AS)
         .append(" ")
         .append(@projected_name)
     end
@@ -233,7 +233,7 @@ module RavenDB
 
       writer
         .append(" ")
-        .append(QueryKeyword::As)
+        .append(QueryKeyword::AS)
         .append(" ")
         .append(@projected_name)
     end
@@ -339,7 +339,7 @@ module RavenDB
       if !@ordering.nil? && (OrderingType::String != @ordering)
         writer
           .append(" ")
-          .append(QueryKeyword::As)
+          .append(QueryKeyword::AS)
           .append(" ")
           .append(@ordering)
       end
@@ -347,7 +347,7 @@ module RavenDB
       if @descending
         writer
           .append(" ")
-          .append(QueryKeyword::Desc)
+          .append(QueryKeyword::DESC)
       end
     end
   end
@@ -620,23 +620,23 @@ module RavenDB
       when WhereOperator::In
         writer
           .append(" ")
-          .append(QueryKeyword::In)
+          .append(QueryKeyword::IN)
           .append(" ($")
           .append(@parameter_name)
           .append(")")
       when WhereOperator::AllIn
         writer
           .append(" ")
-          .append(QueryKeyword::All)
+          .append(QueryKeyword::ALL)
           .append(" ")
-          .append(QueryKeyword::In)
+          .append(QueryKeyword::IN)
           .append(" ($")
           .append(@parameter_name)
           .append(")")
       when WhereOperator::Between
         writer
           .append(" ")
-          .append(QueryKeyword::Between)
+          .append(QueryKeyword::BETWEEN)
           .append(" $")
           .append(@from_parameter_name)
           .append(" ")

--- a/lib/documents/query/query_tokens.rb
+++ b/lib/documents/query/query_tokens.rb
@@ -5,7 +5,7 @@ require "utilities/string_utility"
 
 module RavenDB
   class QueryToken
-    QueryKeywords = [
+    QUERY_KEYWORDS = [
       QueryKeyword::AS,
       QueryKeyword::SELECT,
       QueryKeyword::WHERE,
@@ -22,11 +22,11 @@ module RavenDB
     protected
 
     def write_field(writer, field)
-      is_keyword = QueryKeywords.include?(field)
+      is_keyword = QUERY_KEYWORDS.include?(field)
 
-      is_keyword && writer.append("''")
+      writer.append("''") if is_keyword
       writer.append(field)
-      is_keyword && writer.append("''")
+      writer.append("''") if is_keyword
     end
   end
 

--- a/lib/documents/query/spatial.rb
+++ b/lib/documents/query/spatial.rb
@@ -3,27 +3,27 @@ require "documents/query/query_tokens"
 
 module RavenDB
   class SpatialCriteria
-    def self.relates_to_shape(shape_wkt, relation, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
+    def self.relates_to_shape(shape_wkt, relation, dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       WktCriteria.new(shape_wkt, relation, dist_error_percent)
     end
 
-    def self.intersects(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
+    def self.intersects(shape_wkt, dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       relates_to_shape(shape_wkt, SpatialRelation::INTERSECTS, dist_error_percent)
     end
 
-    def self.contains(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
+    def self.contains(shape_wkt, dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       relates_to_shape(shape_wkt, SpatialRelation::CONTAINS, dist_error_percent)
     end
 
-    def self.disjoint(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
+    def self.disjoint(shape_wkt, dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       relates_to_shape(shape_wkt, SpatialRelation::DISJOINT, dist_error_percent)
     end
 
-    def self.within(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
+    def self.within(shape_wkt, dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       relates_to_shape(shape_wkt, SpatialRelation::WITHIN, dist_error_percent)
     end
 
-    def self.within_radius(radius, latitude, longitude, radius_units = nil, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
+    def self.within_radius(radius, latitude, longitude, radius_units = nil, dist_error_percent = SpatialConstants::DEFAULT_DISTANCE_ERROR_PCT)
       CircleCriteria.new(radius, latitude, longitude, radius_units, SpatialRelations::Within, dist_error_percent)
     end
 

--- a/lib/documents/query/spatial.rb
+++ b/lib/documents/query/spatial.rb
@@ -62,7 +62,7 @@ module RavenDB
       @radius = radius
       @latitude = latitude
       @longitude = longitude
-      @radius_units = radius_units || SpatialUnits::Kilometers
+      @radius_units = radius_units || SpatialUnits::KILOMETERS
     end
 
     def get_shape_token(&spatial_parameter_name_generator)

--- a/lib/documents/query/spatial.rb
+++ b/lib/documents/query/spatial.rb
@@ -8,19 +8,19 @@ module RavenDB
     end
 
     def self.intersects(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
-      relates_to_shape(shape_wkt, SpatialRelation::Intersects, dist_error_percent)
+      relates_to_shape(shape_wkt, SpatialRelation::INTERSECTS, dist_error_percent)
     end
 
     def self.contains(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
-      relates_to_shape(shape_wkt, SpatialRelation::Contains, dist_error_percent)
+      relates_to_shape(shape_wkt, SpatialRelation::CONTAINS, dist_error_percent)
     end
 
     def self.disjoint(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
-      relates_to_shape(shape_wkt, SpatialRelation::Disjoint, dist_error_percent)
+      relates_to_shape(shape_wkt, SpatialRelation::DISJOINT, dist_error_percent)
     end
 
     def self.within(shape_wkt, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)
-      relates_to_shape(shape_wkt, SpatialRelation::Within, dist_error_percent)
+      relates_to_shape(shape_wkt, SpatialRelation::WITHIN, dist_error_percent)
     end
 
     def self.within_radius(radius, latitude, longitude, radius_units = nil, dist_error_percent = SpatialConstants::DefaultDistanceErrorPct)

--- a/lib/requests/request_executor.rb
+++ b/lib/requests/request_executor.rb
@@ -15,7 +15,7 @@ module RavenDB
   class RequestExecutor
     include Observable
 
-    MaxFirstTopologyUpdatesTries = 5
+    MAX_FIRST_TOPOLOGY_UPDATES_TRIES = 5
     attr_reader :initial_database
 
     def initialize(database, options = {})
@@ -100,7 +100,7 @@ module RavenDB
     protected
 
     def is_first_topology_update_tries_expired?
-      @_first_topology_updates_tries >= MaxFirstTopologyUpdatesTries
+      @_first_topology_updates_tries >= MAX_FIRST_TOPOLOGY_UPDATES_TRIES
     end
 
     def await_first_topology_update

--- a/lib/requests/request_helpers.rb
+++ b/lib/requests/request_helpers.rb
@@ -66,8 +66,8 @@ module RavenDB
   end
 
   class NodeStatus
-    MaxTimerPeriod = 60 * 5 * 1000
-    TimerPeriodStep = 0.1 * 1000
+    MAX_TIMER_PERIOD = 60 * 5 * 1000
+    TIMER_PERIOD_STEP = 0.1 * 1000
 
     attr_reader :node_index, :node
 
@@ -80,10 +80,10 @@ module RavenDB
     end
 
     def next_timer_period
-      max_period = MaxTimerPeriod
+      max_period = MAX_TIMER_PERIOD
 
       if @_timer_period < max_period
-        @_timer_period += TimerPeriodStep
+        @_timer_period += TIMER_PERIOD_STEP
       end
 
       [max_period, @_timer_period].min

--- a/spec/raven_commands_tests/patch_command_spec.rb
+++ b/spec/raven_commands_tests/patch_command_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RavenDB::PatchRequest, database: true, database_indexes: true do
 
     expect(result).to include(:Status)
     expect(result).to include(:Document)
-    expect(result[:Status]).to eq(RavenDB::PatchStatus::Patched)
+    expect(result[:Status]).to eq(RavenDB::PatchStatus::PATCHED)
     expect(result[:Document]).to be_kind_of(Product)
     expect(result[:Document].name).to eq("testing")
   end
@@ -26,7 +26,7 @@ RSpec.describe RavenDB::PatchRequest, database: true, database_indexes: true do
 
     expect(result).to include(:Status)
     expect(result).not_to include(:Document)
-    expect(result[:Status]).to eq(RavenDB::PatchStatus::NotModified)
+    expect(result[:Status]).to eq(RavenDB::PatchStatus::NOT_MODIFIED)
   end
 
   it "patches fail not ignoring missing" do

--- a/spec/session_tests/document_attachments_spec.rb
+++ b/spec/session_tests/document_attachments_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RavenDB::AttachmentOperation, database: true do
         RavenDB::PutAttachmentOperation.new(product.id, "1x1.gif", attachment_raw, "image/gif"))
 
       attachment_result = store.operations.send(
-        RavenDB::GetAttachmentOperation.new(product.id, "1x1.gif", RavenDB::AttachmentType::Document))
+        RavenDB::GetAttachmentOperation.new(product.id, "1x1.gif", RavenDB::AttachmentType::DOCUMENT))
 
       expect(attachment_result[:stream]).to eq(attachment_raw)
       expect(attachment_result[:attachment_details][:document_id]).to eq(product.id)
@@ -52,7 +52,7 @@ RSpec.describe RavenDB::AttachmentOperation, database: true do
 
       expect do
         store.operations.send(
-          RavenDB::GetAttachmentOperation.new(product.id, "1x1.gif", RavenDB::AttachmentType::Document))
+          RavenDB::GetAttachmentOperation.new(product.id, "1x1.gif", RavenDB::AttachmentType::DOCUMENT))
       end.to raise_error(RavenDB::DocumentDoesNotExistException)
     end
   end

--- a/spec/session_tests/document_query_spec.rb
+++ b/spec/session_tests/document_query_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RavenDB::DocumentQuery, database: true do
     store.open_session do |session|
       results = session
                 .query(collection: "Products")
-                .using_default_operator(RavenDB::QueryOperator::And)
+                .using_default_operator(RavenDB::QueryOperator::AND)
                 .where_equals("name", "test107")
                 .where_equals("uid", 5)
                 .wait_for_non_stale_results

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require "ravendb"

--- a/spec/support/last_fm_analyzed.rb
+++ b/spec/support/last_fm_analyzed.rb
@@ -14,7 +14,7 @@ class LastFmAnalyzed
     @index_definition = RavenDB::IndexDefinition.new(
       self.class.name, index_map, nil,
       fields: {
-        "query" => RavenDB::IndexFieldOptions.new(RavenDB::FieldIndexingOption::Search)
+        "query" => RavenDB::IndexFieldOptions.new(RavenDB::FieldIndexingOption::SEARCH)
       }
     )
   end


### PR DESCRIPTION
In this PR I didn’t change stuff except the naming convention, but generally in Ruby there is no real benefit of using “enum classes” like this:

```
class AccessMode
    None = "None"
    ReadOnly = "ReadOnly"
    ReadWrite = "ReadWrite"
    Admin = "Admin"
  end
```

Typically a Ruby library would simply operate on symbols (`:read_only` etc), and if some conversion is needed to eg. send a query to server, it would be converted to a different value using a dictionary like `{read_only: “ReadOnly”, read_write: “UsedToBeReadWriteButNowIsWriteRead”, …}`.

Also, and this is more troubling, there are some places that suggest that a constant is used as a variable:

```
if (DocumentConventions::DefaultUseOptimisticConcurrency &&
```

or even explicitly suggest that constant should be redefined by user:

```
  "You can increase the limit by setting RavenDB::DocumentConventions::"\
  "MAX_NUMBER_OF_REQUEST_PER_SESSION
```

In Ruby such use of constants is incorrect, as they should never be redefined.
