### PR TITLE
RDBC-149: Gitlab CI configuration for Ruby client

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,123 @@
+variables:
+  DOCKER_IMAGE_VERSION: 1
+  RUNNER_IMAGE_TAG: $CI_REGISTRY_IMAGE/runner:$DOCKER_IMAGE_VERSION
+  SERVER_HTTP_IMAGE_TAG: $CI_REGISTRY_IMAGE/server_http:$DOCKER_IMAGE_VERSION
+  SERVER_HTTPS_IMAGE_TAG: $CI_REGISTRY_IMAGE/server_https:$DOCKER_IMAGE_VERSION
+  RUBY_24: "2.4.3"
+  RUBY_25: "2.5.0"
+  PASSPHRASE: client11
+  CERTIFICATE: ./ruby.pem
+
+image: $RUNNER_IMAGE_TAG
+
+stages:
+  - docker
+  - extract
+  - test
+
+docker_runner_image:
+  stage: docker
+  tags:
+    - dockerbuild
+  image: docker:latest
+  script:
+    - cd spec/fixtures && docker build -t $RUNNER_IMAGE_TAG -f Dockerfile.runner --build-arg RUBY_24=$RUBY_24 --build-arg RUBY_25=$RUBY_25 .
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker push $RUNNER_IMAGE_TAG
+
+docker_server_http_image:
+  stage: docker
+  tags:
+    - dockerbuild
+  image: docker:latest
+  script:
+    - cd spec/fixtures && docker build -t $SERVER_HTTP_IMAGE_TAG -f Dockerfile.server_http .
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker push $SERVER_HTTP_IMAGE_TAG
+
+docker_server_https_image:
+  stage: docker
+  tags:
+    - dockerbuild
+  image: docker:latest
+  script:
+    - cd spec/fixtures && docker build -t $SERVER_HTTPS_IMAGE_TAG -f Dockerfile.server_https --build-arg PASSPHRASE=$PASSPHRASE .
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker push $SERVER_HTTPS_IMAGE_TAG
+
+extract_certificate:
+  stage: extract
+  tags:
+    - dockerbuild
+  image: docker:latest
+  script:
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker pull $SERVER_HTTPS_IMAGE_TAG
+    - docker run --rm $SERVER_HTTPS_IMAGE_TAG cat /certs/ruby.pem > ruby.pem
+    - docker run --rm $SERVER_HTTPS_IMAGE_TAG cat /certs/ca.crt > ca.crt
+  artifacts:
+    paths:
+      - ruby.pem
+      - ca.crt
+    expire_in: 1 week
+
+.rspec: &rspec
+  stage: test
+  script:
+    - cp ca.crt /usr/local/share/ca-certificates/ca.crt; update-ca-certificates; true
+    - curl -v $URL
+    - bundle install --path=/cache/bundler
+    - bundle exec rspec
+
+.ruby_24: &ruby_24
+  tags:
+    - ruby
+  before_script:
+    - source /usr/share/rvm/scripts/rvm
+    - rvm use $RUBY_24
+    - ruby -v
+
+.ruby_25: &ruby_25
+  tags:
+    - ruby
+  before_script:
+    - source /usr/share/rvm/scripts/rvm
+    - rvm use $RUBY_25   
+    - ruby -v
+
+.http: &http
+  services:
+    - name: $SERVER_HTTP_IMAGE_TAG
+      alias: ravendb
+  variables:
+    URL: http://ravendb:8080
+
+.https: &https
+  services:
+    - name: $SERVER_HTTPS_IMAGE_TAG
+      alias: ravendb
+  variables:
+    URL: https://ravendb:8433
+    HTTPS: "true"
+  dependencies:
+    - extract_certificate
+
+rspec_24_http:
+  <<: *rspec
+  <<: *ruby_24
+  <<: *http
+
+rspec_24_https:
+  <<: *rspec
+  <<: *ruby_24
+  <<: *https
+
+rspec_25_http:
+  <<: *rspec
+  <<: *ruby_25
+  <<: *http
+
+rspec_25_https:
+  <<: *rspec
+  <<: *ruby_25
+  <<: *https

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,47 +12,23 @@ image: $RUNNER_IMAGE_TAG
 
 stages:
   - docker
-  - extract
   - test
 
-docker_runner_image:
+docker:
   stage: docker
   tags:
     - dockerbuild
   image: docker:latest
   script:
-    - cd spec/fixtures && docker build -t $RUNNER_IMAGE_TAG -f Dockerfile.runner --build-arg RUBY_24=$RUBY_24 --build-arg RUBY_25=$RUBY_25 .
+    - cd spec/fixtures
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker build -t $RUNNER_IMAGE_TAG -f Dockerfile.runner --build-arg RUBY_24=$RUBY_24 --build-arg RUBY_25=$RUBY_25 .
     - docker push $RUNNER_IMAGE_TAG
-
-docker_server_http_image:
-  stage: docker
-  tags:
-    - dockerbuild
-  image: docker:latest
-  script:
-    - cd spec/fixtures && docker build -t $SERVER_HTTP_IMAGE_TAG -f Dockerfile.server_http .
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker build -t $SERVER_HTTP_IMAGE_TAG -f Dockerfile.server_http .
     - docker push $SERVER_HTTP_IMAGE_TAG
-
-docker_server_https_image:
-  stage: docker
-  tags:
-    - dockerbuild
-  image: docker:latest
-  script:
-    - cd spec/fixtures && docker build -t $SERVER_HTTPS_IMAGE_TAG -f Dockerfile.server_https --build-arg PASSPHRASE=$PASSPHRASE .
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker build -t $SERVER_HTTPS_IMAGE_TAG -f Dockerfile.server_https --build-arg PASSPHRASE=$PASSPHRASE .
     - docker push $SERVER_HTTPS_IMAGE_TAG
-
-extract_certificate:
-  stage: extract
-  tags:
-    - dockerbuild
-  image: docker:latest
-  script:
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-    - docker pull $SERVER_HTTPS_IMAGE_TAG
+    - cd ../..
     - docker run --rm $SERVER_HTTPS_IMAGE_TAG cat /certs/ruby.pem > ruby.pem
     - docker run --rm $SERVER_HTTPS_IMAGE_TAG cat /certs/ca.crt > ca.crt
   artifacts:
@@ -100,7 +76,7 @@ extract_certificate:
     URL: https://ravendb:8433
     HTTPS: "true"
   dependencies:
-    - extract_certificate
+    - docker
 
 rspec_24_http:
   <<: *rspec

--- a/spec/fixtures/Dockerfile.runner
+++ b/spec/fixtures/Dockerfile.runner
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install \
+  software-properties-common \
+  -y
+
+RUN apt-add-repository ppa:rael-gc/rvm
+
+RUN apt-get update && apt-get install \
+  git \
+  rvm \
+  -y
+
+ARG RUBY_24
+ARG RUBY_25
+
+RUN /bin/bash -l -c "source /usr/share/rvm/scripts/rvm; rvm install ${RUBY_24}"
+RUN /bin/bash -l -c "source /usr/share/rvm/scripts/rvm; rvm install ${RUBY_25}"
+
+RUN /bin/bash -l -c "source /usr/share/rvm/scripts/rvm; rvm ${RUBY_24} do gem install bundler"
+RUN /bin/bash -l -c "source /usr/share/rvm/scripts/rvm; rvm ${RUBY_25} do gem install bundler"

--- a/spec/fixtures/Dockerfile.server_http
+++ b/spec/fixtures/Dockerfile.server_http
@@ -1,0 +1,20 @@
+FROM ubuntu:14.04
+
+RUN apt-get -qq update
+RUN apt-get install -y libunwind8 wget libicu52 libssl-dev curl unzip gettext libcurl4-openssl-dev zlib1g uuid-dev bzip2 openssl
+
+RUN mkdir /server
+RUN cd /server; wget -O RavenDB.tar.bz2 https://hibernatingrhinos.com/downloads/RavenDB%20for%20Linux%20x64/latest
+RUN cd /server; tar xvjf RavenDB.tar.bz2
+
+RUN mkdir /config
+COPY cert/* /config/
+
+RUN cp /config/test_settings_http.json /server/RavenDB/Server/settings.json
+
+CMD /server/RavenDB/Server/Raven.Server --non-interactive
+
+EXPOSE 8080
+
+HEALTHCHECK --start-period=30s --interval=10s --timeout=5s --retries=3 \
+  CMD curl -f http://localhost:8080/ || exit 1

--- a/spec/fixtures/Dockerfile.server_https
+++ b/spec/fixtures/Dockerfile.server_https
@@ -36,4 +36,4 @@ CMD /server/RavenDB/Server/Raven.Server --non-interactive
 EXPOSE 8433
 
 HEALTHCHECK --start-period=30s --interval=10s --timeout=5s --retries=3 \
-  CMD curl -f https://localhost:8433/ || exit 1
+  CMD curl -f -k https://localhost:8433/ || exit 1

--- a/spec/fixtures/Dockerfile.server_https
+++ b/spec/fixtures/Dockerfile.server_https
@@ -1,0 +1,39 @@
+FROM ubuntu:14.04
+
+RUN apt-get -qq update
+RUN apt-get install -y libunwind8 wget libicu52 libssl-dev curl unzip gettext libcurl4-openssl-dev zlib1g uuid-dev bzip2 openssl
+
+RUN mkdir /server
+RUN cd /server; wget -O RavenDB.tar.bz2 https://hibernatingrhinos.com/downloads/RavenDB%20for%20Linux%20x64/latest
+RUN cd /server; tar xvjf RavenDB.tar.bz2
+
+RUN mkdir /config
+COPY cert/* /config/
+
+RUN cp /config/test_settings_https.json /server/RavenDB/Server/settings.json
+
+ARG PASSPHRASE
+
+RUN mkdir /certs
+RUN cd /certs; openssl genrsa -out ca.key 2048
+RUN cd /certs; openssl req -new -x509 -key ca.key -out ca.crt -subj "/C=US/ST=Arizona/L=Nevada/O=RavenDB Test CA/OU=RavenDB test CA/CN=ravendb/emailAddress=ravendbca@example.com"
+RUN cd /certs; openssl genrsa -out localhost.key 2048
+RUN cd /certs; openssl req -new  -key localhost.key -out localhost.csr -subj "/C=US/ST=Arizona/L=Nevada/O=RavenDB Test/OU=RavenDB test/CN=ravendb/emailAddress=ravendb@example.com"
+RUN cd /certs; openssl x509 -req -extensions ext -extfile /config/test_cert.conf -in localhost.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out localhost.crt
+RUN cd /certs; cat localhost.key localhost.crt > ruby.pem
+RUN cd /certs; openssl pkcs12 -passout pass:$PASSPHRASE -export -out server.pfx -inkey localhost.key -in localhost.crt
+RUN cd /certs; cp ca.crt /usr/local/share/ca-certificates/ca.crt
+
+RUN update-ca-certificates
+
+ENV RAVEN_PFX=/certs/server.pfx
+
+RUN sed -i 's@PFX@'"$RAVEN_PFX"'@' /server/RavenDB/Server/settings.json
+RUN sed -i s/PASS/$PASSPHRASE/ /server/RavenDB/Server/settings.json
+
+CMD /server/RavenDB/Server/Raven.Server --non-interactive
+
+EXPOSE 8433
+
+HEALTHCHECK --start-period=30s --interval=10s --timeout=5s --retries=3 \
+  CMD curl -f https://localhost:8433/ || exit 1

--- a/spec/fixtures/cert/test_settings_http.json
+++ b/spec/fixtures/cert/test_settings_http.json
@@ -1,5 +1,6 @@
 {
-    "ServerUrl": "http://127.0.0.1:8080",
+    "ServerUrl": "http://0.0.0.0:8080",
     "Setup.Mode": "Initial",
-    "DataDir": "RavenData"
+    "DataDir": "RavenData",
+    "Security.UnsecuredAccessAllowed": "PublicNetwork"
 }

--- a/spec/fixtures/cert/test_settings_https.json
+++ b/spec/fixtures/cert/test_settings_https.json
@@ -1,5 +1,5 @@
 {
-    "ServerUrl": "https://127.0.0.1:8433",
+    "ServerUrl": "https://0.0.0.0:8433",
     "Setup.Mode": "Initial",
     "DataDir": "RavenData",
     "Security.Certificate.Path": "PFX",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require "ravendb"
 require "date"
 require "securerandom"
 
-Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
+Dir[File.dirname(__FILE__) + "/support/**/*.rb"].sort.each { |f| require f }
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/support/test_custom_serializer.rb
+++ b/spec/support/test_custom_serializer.rb
@@ -1,3 +1,5 @@
+require "support/test_custom_document_id"
+
 class TestCustomSerializer < TestCustomDocumentId
   attr_accessor :item_options
 


### PR DESCRIPTION
I wanted to have faster turnaround times for HTTPS tests. On Travis I am limited to 4 concurrent tests, however I have a private Gitlab test farm that can do the job much faster. This is basically a 1:1 port of Travis CI setup to Gitlab.